### PR TITLE
Fixing Regex to enter right directory of Clang report file

### DIFF
--- a/lib/Analizo/Extractor/ClangStaticAnalyzer.pm
+++ b/lib/Analizo/Extractor/ClangStaticAnalyzer.pm
@@ -32,12 +32,11 @@ sub actually_process {
   my $files_list = join(' ', @input_files);
   my $output_folder = "/tmp/analizo-clang-analyzer";
 
-  #FIXME: Insert regex to enter right directory
-  my $html_report = "$output_folder/2014-01-09-1/index.html";
   my $analyze_command = "scan-build -o $output_folder gcc -c $files_list >/dev/null 2>/dev/null";
 
   #FIXME: Eval removed due to returning bug
   system($analyze_command);
+  my $html_report = glob("$output_folder/*/index.html");
   %metrics = $self->filter_html_report($html_report);
   system("rm -rf $output_folder");
   $self->feed(%metrics);


### PR DESCRIPTION
I used glob function to find and return the first report file found.
